### PR TITLE
Make use of ExceptionGroup when autodetection of style fails.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14-dev"]
+        python-version: ["3.11", "3.12", "3.13", "3.14-dev"]
     steps:
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ maintainers = [{ name = "Jan-Eric Nitschke", email = "janericnitschke@gmail.com"
 license = { text = "MIT" }
 description = "Generate, fix and convert docstrings."
 readme = { file = "README.rst", content-type = "text/x-rst" }
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 keywords = ["pymend", "docstring"]
 classifiers = [
     "Intended Audience :: Developers",
@@ -18,7 +18,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -98,8 +97,8 @@ exclude = [
 # Same as Black.
 line-length = 88
 
-# Assume Python 3.9.
-target-version = "py39"
+# Assume Python 3.11.
+target-version = "py311"
 
 [tool.ruff.lint]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.

--- a/src/pymend/docstring_parser/base_parser.py
+++ b/src/pymend/docstring_parser/base_parser.py
@@ -37,24 +37,25 @@ def parse(
 
     Raises
     ------
-    ParserError
+    ExceptionGroup
         If none of the available modules can parse the docstring
     """
     if style != DocstringStyle.AUTO:
         return _STYLE_MAP[style].parse(text)
 
-    exc: Optional[Exception] = None
+    exc: list[Exception] = []
     rets: list[Docstring] = []
     for module in _STYLE_MAP.values():
         try:
             ret = module.parse(text)
         except ParseError as ex:
-            exc = ex
+            exc.append(ex)
         else:
             rets.append(ret)
 
     if not rets and exc:
-        raise exc
+        msg = "No parser could parse the docstring."
+        raise ExceptionGroup(msg, exc)
 
     return sorted(rets, key=lambda d: (len(d.examples), len(d.meta)), reverse=True)[0]
 

--- a/tests/test_docstring_parser/test_parser.py
+++ b/tests/test_docstring_parser/test_parser.py
@@ -221,7 +221,7 @@ def test_autodetection_error() -> None:
     }
     with (
         patch("pymend.docstring_parser.base_parser._STYLE_MAP", patched_map),
-        pytest.raises(ParseError),
+        pytest.raises(ExceptionGroup),
     ):
         base_parser.parse(source)
 

--- a/tests/test_docstring_parser/test_parser.py
+++ b/tests/test_docstring_parser/test_parser.py
@@ -221,7 +221,7 @@ def test_autodetection_error() -> None:
     }
     with (
         patch("pymend.docstring_parser.base_parser._STYLE_MAP", patched_map),
-        pytest.raises(ExceptionGroup),
+        pytest.RaisesGroup(ParseError),
     ):
         base_parser.parse(source)
 


### PR DESCRIPTION
Fixes https://github.com/JanEricNitschke/pymend/issues/76

Can be used once 3.9 and 3.10 become EOL in late 2026