### PR TITLE
Add checking of option names in pyproject

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           args: "format --check"
       - name: Typecheck with pyright
-        uses: jakebailey/pyright-action@8ec14b5cfe41f26e5f41686a31eb6012758217ef # v3
+        run: uv run pyright
 
       - name: Thorough check with pylint
         run: uv run pylint src/pymend

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ extend-exclude             = "docs/|tests/"
 output-style               = "numpydoc"
 input-style                = "numpydoc"
 ignored-functions          = ["main"]
-check                      = true
 force-meta-min-func-length = 5
 force-params-min-n-params  = 2
 
@@ -168,13 +167,13 @@ skip-magic-trailing-comma = false
 
 [tool.coverage.run]
 branch = true
-source = ["pymend"]
+source = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
 [tool.pyright]
-include                            = ["pymend"]
+include                            = ["src"]
 exclude                            = ["tests"]
 typeCheckingMode                   = "strict"
 strictListInference                = true

--- a/src/pymend/option_groups.py
+++ b/src/pymend/option_groups.py
@@ -155,9 +155,27 @@ class GroupTitle(click.Option):
         """Return the group title as a help record."""
         return f"{self._group.name} [mutually exclusive]:", self._group.help
 
-    def get_option_names(self) -> list[str]:
-        """Return the list of option names of the group."""
-        return self._group.option_names
+    def get_destination(self) -> str:
+        """Return the destination (click parameter name) for this group.
+
+        Returns
+        -------
+        str
+            The destination name.
+
+        Raises
+        ------
+        SystemExit
+            If the destination was never set, indicating an internal error.
+        """
+        if self._group.destination is None:
+            err(
+                internal_error_message(
+                    f"Group '{self._group.name}' has no destination set."
+                )
+            )
+            sys.exit(INTERNAL_FAILURE_EXIT_CODE)
+        return self._group.destination
 
 
 class MutuallyExclusiveOptionGroup:  # pylint: disable=too-few-public-methods
@@ -177,7 +195,7 @@ class MutuallyExclusiveOptionGroup:  # pylint: disable=too-few-public-methods
         self.help = help
         self._pending = 0
         self._applied = 0
-        self.option_names: list[str] = []
+        self.destination: str | None = None
 
     def option(  # pylint: disable=redefined-builtin
         self,
@@ -214,6 +232,18 @@ class MutuallyExclusiveOptionGroup:  # pylint: disable=too-few-public-methods
             A decorator that registers the option on the click command.
         """
         self._pending += 1
+
+        if self.destination is None:
+            self.destination = destination
+        elif self.destination != destination:
+            err(
+                internal_error_message(
+                    f"All options in group '{self.name}' must have the"
+                    f" same destination. Got '{destination}' but expected"
+                    f" '{self.destination}'."
+                )
+            )
+            sys.exit(INTERNAL_FAILURE_EXIT_CODE)
 
         def decorator(func: _FC) -> _FC:
             """Register the grouped option on the decorated function.
@@ -257,7 +287,6 @@ class MutuallyExclusiveOptionGroup:  # pylint: disable=too-few-public-methods
                     sys.exit(INTERNAL_FAILURE_EXIT_CODE)
 
             params.append(grouped_option)
-            self.option_names.append(flag)
 
             self._applied += 1
             if self._applied == self._pending:

--- a/src/pymend/option_groups.py
+++ b/src/pymend/option_groups.py
@@ -132,7 +132,7 @@ class _GroupedOption(click.Option):
         return f"  {opts}", help_text
 
 
-class _GroupTitle(click.Option):
+class GroupTitle(click.Option):
     """Invisible option that renders the group heading in `--help`."""
 
     def __init__(self, group: MutuallyExclusiveOptionGroup) -> None:
@@ -155,6 +155,10 @@ class _GroupTitle(click.Option):
         """Return the group title as a help record."""
         return f"{self._group.name} [mutually exclusive]:", self._group.help
 
+    def get_option_names(self) -> list[str]:
+        """Return the list of option names of the group."""
+        return self._group.option_names
+
 
 class MutuallyExclusiveOptionGroup:  # pylint: disable=too-few-public-methods
     """A named set of click options where at most one may be provided."""
@@ -173,6 +177,7 @@ class MutuallyExclusiveOptionGroup:  # pylint: disable=too-few-public-methods
         self.help = help
         self._pending = 0
         self._applied = 0
+        self.option_names: list[str] = []
 
     def option(  # pylint: disable=redefined-builtin
         self,
@@ -252,10 +257,11 @@ class MutuallyExclusiveOptionGroup:  # pylint: disable=too-few-public-methods
                     sys.exit(INTERNAL_FAILURE_EXIT_CODE)
 
             params.append(grouped_option)
+            self.option_names.append(flag)
 
             self._applied += 1
             if self._applied == self._pending:
-                params.append(_GroupTitle(self))
+                params.append(GroupTitle(self))
 
             return func
 

--- a/src/pymend/pymendapp.py
+++ b/src/pymend/pymendapp.py
@@ -3,7 +3,6 @@
 
 import platform
 import re
-import sys
 import traceback
 from pathlib import Path
 from re import Pattern
@@ -17,9 +16,7 @@ from pymend import PyComment, __version__
 
 from .const import (
     DEFAULT_EXCLUDES,
-    INTERNAL_FAILURE_EXIT_CODE,
     OutputMode,
-    internal_error_message,
 )
 from .docstring_info import FixerSettings, ForceOption, RaisesForceMode
 from .files import find_pyproject_toml, parse_pyproject_toml
@@ -28,7 +25,7 @@ from .option_groups import (
     GroupTitle,
     MutuallyExclusiveOptionGroup,
 )
-from .output import err, out
+from .output import out
 from .report import Report
 
 # --- Mutually exclusive option groups ---
@@ -64,8 +61,14 @@ STRING_TO_STYLE = {
     "google": dsp.DocstringStyle.GOOGLE,
 }
 
-FORCE_OPTION_KEYS = {"force_arg_types", "force_return_type", "force_attribute_types"}
-RAISES_FORCE_KEYS = {"force_raises"}
+FORCE_OPTION_KEYS = frozenset(
+    {"force_arg_types", "force_return_type", "force_attribute_types"}
+)
+RAISES_FORCE_KEYS = frozenset({"force_raises"})
+
+_OPTIONS_NOT_IN_PYPROJECT = frozenset(
+    {"verbose", "quiet", "config", "src", "version", "help"}
+)
 
 
 def path_is_excluded(
@@ -289,42 +292,24 @@ def _process_raises_force_options(config: dict[str, object]) -> None:
 
 
 def _get_all_option_names(ctx: click.Context) -> list[str]:
-    """Get a sorted list of all option names according to the defined options.
+    """Get a sorted list of option names allowed in pyproject.toml.
 
     Returns
     -------
     list[str]
-        List of all possible option names
+        List of all option names valid in pyproject.toml
     """
     option_names: set[str] = set()
     for param in ctx.command.get_params(ctx):
-        if param.name in {"version", "help"}:
-            # Ignore fields that should never be in the pyproject file to begin with
-            continue
-
-        if param.name is None:
-            continue
-
-        if not param.name.startswith("_grp"):
-            # Standard fields, add to set of options
-            option_names.add(param.name)
-            continue
-
-        if not isinstance(param, GroupTitle):
-            err(
-                internal_error_message(
-                    "Something went wrong when passing through"
-                    " the options of the context"
-                )
-            )
-            sys.exit(INTERNAL_FAILURE_EXIT_CODE)
-
-        # The option names are still as they are passed in the CLI,
-        # so need to remove the '--'
-        option_names.update(
-            name.replace("--", "").replace("-", "_")
-            for name in param.get_option_names()
-        )
+        match param:
+            case GroupTitle():
+                option_names.add(param.get_destination())
+            case click.Option() if (
+                param.name is not None and param.name not in _OPTIONS_NOT_IN_PYPROJECT
+            ):
+                option_names.add(param.name)
+            case click.Parameter():
+                continue
 
     return sorted(option_names)
 
@@ -342,7 +327,7 @@ def _validate_option_names(config: dict[str, object], ctx: click.Context) -> Non
     Raises
     ------
     click.UsageError
-        If a key of `config` is not an option in `ctx`.
+        If a key of `config` is not a valid option.
     """
     option_names = _get_all_option_names(ctx)
 
@@ -354,7 +339,7 @@ def _validate_option_names(config: dict[str, object], ctx: click.Context) -> Non
     if not invalid_keys:
         return
 
-    formatted_option_names = [name.replace("_", "-") for name in option_names]
+    formatted_option_names = ", ".join(name.replace("_", "-") for name in option_names)
     if len(invalid_keys) == 1:
         msg = (
             f"Found unknown option in pyproject.toml: {invalid_keys[0]}.\n"
@@ -362,7 +347,7 @@ def _validate_option_names(config: dict[str, object], ctx: click.Context) -> Non
         )
     else:
         msg = (
-            f"Found unknown options in pyproject.toml: {invalid_keys}.\n"
+            f"Found unknown options in pyproject.toml: {', '.join(invalid_keys)}.\n"
             f"Expected a subset of {formatted_option_names}"
         )
     raise click.UsageError(msg)

--- a/src/pymend/pymendapp.py
+++ b/src/pymend/pymendapp.py
@@ -3,6 +3,7 @@
 
 import platform
 import re
+import sys
 import traceback
 from pathlib import Path
 from re import Pattern
@@ -14,11 +15,20 @@ from click.core import ParameterSource
 import pymend.docstring_parser as dsp
 from pymend import PyComment, __version__
 
-from .const import DEFAULT_EXCLUDES, OutputMode
+from .const import (
+    DEFAULT_EXCLUDES,
+    INTERNAL_FAILURE_EXIT_CODE,
+    OutputMode,
+    internal_error_message,
+)
 from .docstring_info import FixerSettings, ForceOption, RaisesForceMode
 from .files import find_pyproject_toml, parse_pyproject_toml
-from .option_groups import ExclusiveGroupCommand, MutuallyExclusiveOptionGroup
-from .output import out
+from .option_groups import (
+    ExclusiveGroupCommand,
+    GroupTitle,
+    MutuallyExclusiveOptionGroup,
+)
+from .output import err, out
 from .report import Report
 
 # --- Mutually exclusive option groups ---
@@ -278,6 +288,86 @@ def _process_raises_force_options(config: dict[str, object]) -> None:
                     ) from None
 
 
+def _get_all_option_names(ctx: click.Context) -> list[str]:
+    """Get a sorted list of all option names according to the defined options.
+
+    Returns
+    -------
+    list[str]
+        List of all possible option names
+    """
+    option_names: set[str] = set()
+    for param in ctx.command.get_params(ctx):
+        if param.name in {"version", "help"}:
+            # Ignore fields that should never be in the pyproject file to begin with
+            continue
+
+        if param.name is None:
+            continue
+
+        if not param.name.startswith("_grp"):
+            # Standard fields, add to set of options
+            option_names.add(param.name)
+            continue
+
+        if not isinstance(param, GroupTitle):
+            err(
+                internal_error_message(
+                    "Something went wrong when passing through"
+                    " the options of the context"
+                )
+            )
+            sys.exit(INTERNAL_FAILURE_EXIT_CODE)
+
+        # The option names are still as they are passed in the CLI,
+        # so need to remove the '--'
+        option_names.update(
+            name.replace("--", "").replace("-", "_")
+            for name in param.get_option_names()
+        )
+
+    return sorted(option_names)
+
+
+def _validate_option_names(config: dict[str, object], ctx: click.Context) -> None:
+    """Validate that all the keys in the configuration are valid.
+
+    Parameters
+    ----------
+    config : dict[str, object]
+        configuration, parsed from pyproject.toml
+    ctx : click.Context
+        click Context with all the options
+
+    Raises
+    ------
+    click.UsageError
+        If a key of `config` is not an option in `ctx`.
+    """
+    option_names = _get_all_option_names(ctx)
+
+    invalid_keys: list[str] = []
+    for key in config:
+        if key not in option_names:
+            invalid_keys.append(key.replace("_", "-"))
+
+    if not invalid_keys:
+        return
+
+    formatted_option_names = [name.replace("_", "-") for name in option_names]
+    if len(invalid_keys) == 1:
+        msg = (
+            f"Found unknown option in pyproject.toml: {invalid_keys[0]}.\n"
+            f"Expected one of {formatted_option_names}"
+        )
+    else:
+        msg = (
+            f"Found unknown options in pyproject.toml: {invalid_keys}.\n"
+            f"Expected a subset of {formatted_option_names}"
+        )
+    raise click.UsageError(msg)
+
+
 def _validate_exclude_options(config: dict[str, object]) -> None:
     """Validate exclude options in config.
 
@@ -362,6 +452,7 @@ def read_pyproject_toml(
         k: str(v) if not isinstance(v, (list, dict)) else v for k, v in config.items()
     }
 
+    _validate_option_names(config, ctx)
     _validate_exclude_options(config)
     _process_force_options(config)
     _process_raises_force_options(config)

--- a/tests/test_pymend/test_app.py
+++ b/tests/test_pymend/test_app.py
@@ -6,7 +6,6 @@ import subprocess
 import tempfile
 import textwrap
 from dataclasses import asdict
-from enum import Enum
 from pathlib import Path
 from re import Pattern
 
@@ -276,118 +275,164 @@ class TestApp:
             expected_returncode=1,
         )
 
-    def test_valid_pyproject_passes(self) -> None:
+    def test_valid_pyproject_passes(self, tmp_path: Path) -> None:
         """Test that the valid options in pyproject succeed."""
-        options = [
-            ("force_docstrings", True),
-            ("force_params", True),
-            ("force_return", True),
-            ("force_raises", pymend.docstring_info.RaisesForceMode.PER_SITE),
-            ("force_methods", False),
-            ("force_attributes", False),
-            ("force_params_min_n_params", 0),
-            ("force_meta_min_func_length", 0),
-            ("ignore_privates", True),
-            ("ignore_unused_arguments", True),
-            ("ignored_decorators", ["overload"]),
-            ("ignored_functions", ["main"]),
-            ("ignored_classes", []),
-            ("force_defaults", True),
-            ("force_return_type", pymend.docstring_info.ForceOption.FORCE),
-            ("force_arg_types", pymend.docstring_info.ForceOption.FORCE),
-            ("force_attribute_types", pymend.docstring_info.ForceOption.FORCE),
-            ("force_summary_period", True),
-            ("force_summary_blank_line", True),
-            ("force_multiline_docs_end_with_blank", False),
-            ("indent", 4),
-            ("attribute_class_decorators", ["dataclass"]),
-            ("attribute_base_classes", ["BaseModel"]),
-            ("property_decorators", ["property"]),
-            ("additional_excluded_decorators", ["staticmethod", "classmethod"]),
-        ]
+        pyproject_content = textwrap.dedent("""\
+            [tool.pymend]
+            mode = "diff"
+            output-style = "numpydoc"
+            input-style = "numpydoc"
+            exclude = "docs/|tests/"
+            extend-exclude = "build/"
+            force-docstrings = true
+            force-params = true
+            force-return = true
+            force-raises = "per-site"
+            force-methods = false
+            force-attributes = false
+            force-params-min-n-params = 0
+            force-meta-min-func-length = 0
+            ignore-privates = true
+            ignore-unused-arguments = true
+            ignored-decorators = ["overload"]
+            ignored-functions = ["main"]
+            ignored-classes = []
+            force-defaults = true
+            force-return-type = "force"
+            force-arg-types = "force"
+            force-attribute-types = "force"
+            force-summary-period = true
+            force-summary-blank-line = true
+            force-multiline-docs-end-with-blank = false
+            indent = 4
+            attribute-class-decorators = ["dataclass"]
+            attribute-base-classes = ["BaseModel"]
+            property-decorators = ["property"]
+            additional-excluded-decorators = ["staticmethod", "classmethod"]
+        """)
 
-        settings_dict = asdict(pymend.pymend.FixerSettings())
-        assert len(options) == len(settings_dict)
-        for name, _ in options:
-            assert name in settings_dict
+        n_options = len([line for line in pyproject_content.split("\n") if "=" in line])
+        n_non_fixer_options = len(
+            ["mode", "output-style", "input-style", "exclude", "extend-exclude"]
+        )
+        assert (
+            n_options
+            == len(asdict(pymend.pymend.FixerSettings())) + n_non_fixer_options
+        )
 
-        with tempfile.NamedTemporaryFile(mode="w", dir=self.CWD) as pyproject_file:
-            pyproject_file.write("[tool.pymend]\n")
-            for name, value in options:
-                if isinstance(value, Enum):
-                    value = value.value  # noqa: PLW2901
-                if isinstance(value, str):
-                    value = f'"{value}"'  # noqa: PLW2901
-                if isinstance(value, bool):
-                    value = str(value).lower()  # noqa: PLW2901
-                pyproject_file.write(f"{name} = {value}\n")
-            pyproject_file.flush()
+        pyproject_file = tmp_path / "pyproject.toml"
+        pyproject_file.write_text(pyproject_content)
 
-            self.run_pymend_app_and_assert_is_expected(
-                cmd_args=(
-                    f"--config {pyproject_file.name} {self.CWD}/src/pymend/pymend.py"
-                ),
-                expected_stderr=re.compile(
-                    "All done!",
-                    re.DOTALL,
-                ),
-            )
+        self.run_pymend_app_and_assert_is_expected(
+            cmd_args=(f"--config {pyproject_file} {self.CWD}/src/pymend/pymend.py"),
+            expected_stderr=re.compile(
+                "All done!",
+                re.DOTALL,
+            ),
+        )
 
-    def test_invalid_value_type_pyproject_options_raises(self) -> None:
+    def test_invalid_value_type_pyproject_options_raises(self, tmp_path: Path) -> None:
         """Test that a valid option but with invalid type in pyproject fails."""
-        with tempfile.NamedTemporaryFile(mode="w", dir=self.CWD) as pyproject_file:
-            pyproject_file.write("[tool.pymend]\nforce-docstrings = '5'\n")
-            pyproject_file.flush()
+        pyproject_file = tmp_path / "pyproject.toml"
+        pyproject_file.write_text(
+            textwrap.dedent("""\
+            [tool.pymend]
+            force-docstrings = '5'
+        """)
+        )
 
-            self.run_pymend_app_and_assert_is_expected(
-                cmd_args=(
-                    f"--config {pyproject_file.name} {self.CWD}/src/pymend/pymend.py"
-                ),
-                expected_stderr=re.compile(
-                    r"Usage: pymend \[OPTIONS\] SRC \.\.\..*"
-                    r"Error: Invalid value for '--force-docstrings': '5'",
-                    re.DOTALL,
-                ),
-                expected_returncode=2,
-            )
+        self.run_pymend_app_and_assert_is_expected(
+            cmd_args=(f"--config {pyproject_file} {self.CWD}/src/pymend/pymend.py"),
+            expected_stderr=re.compile(
+                r"Usage: pymend \[OPTIONS\] SRC \.\.\..*"
+                r"Error: Invalid value for '--force-docstrings': '5'",
+                re.DOTALL,
+            ),
+            expected_returncode=2,
+        )
 
-    def test_invalid_pyproject_option_raises(self) -> None:
+    def test_invalid_pyproject_option_raises(self, tmp_path: Path) -> None:
         """Test that a pyproject.toml file with an invalid option reports an error."""
-        with tempfile.NamedTemporaryFile(mode="w", dir=self.CWD) as pyproject_file:
-            pyproject_file.write("[tool.pymend]\ninvalid_option = '5'\n")
-            pyproject_file.flush()
+        pyproject_file = tmp_path / "pyproject.toml"
+        pyproject_file.write_text(
+            textwrap.dedent("""\
+            [tool.pymend]
+            invalid-option = '5'
+        """)
+        )
 
-            self.run_pymend_app_and_assert_is_expected(
-                cmd_args=(
-                    f"--config {pyproject_file.name} {self.CWD}/src/pymend/pymend.py"
-                ),
-                expected_stderr=re.compile(
-                    r"Usage: pymend \[OPTIONS\] SRC \.\.\..*"
-                    r"Error: Found unknown option in pyproject.toml: *",
-                    re.DOTALL,
-                ),
-                expected_returncode=2,
-            )
+        self.run_pymend_app_and_assert_is_expected(
+            cmd_args=(f"--config {pyproject_file} {self.CWD}/src/pymend/pymend.py"),
+            expected_stderr=re.compile(
+                r"Usage: pymend \[OPTIONS\] SRC \.\.\..*"
+                r"Error: Found unknown option in pyproject.toml: *",
+                re.DOTALL,
+            ),
+            expected_returncode=2,
+        )
 
-    def test_invalid_pyproject_options_raises(self) -> None:
+    def test_invalid_pyproject_options_raises(self, tmp_path: Path) -> None:
         """Test that a pyproject file with multiple invalid options raises an error."""
-        with tempfile.NamedTemporaryFile(mode="w", dir=self.CWD) as pyproject_file:
-            pyproject_file.write(
-                "[tool.pymend]\ninvalid-option = '5'\nother-invalid-option = true\n"
-            )
-            pyproject_file.flush()
+        pyproject_file = tmp_path / "pyproject.toml"
+        pyproject_file.write_text(
+            textwrap.dedent("""\
+            [tool.pymend]
+            invalid-option = '5'
+            other-invalid-option = true
+        """)
+        )
 
-            self.run_pymend_app_and_assert_is_expected(
-                cmd_args=(
-                    f"--config {pyproject_file.name} {self.CWD}/src/pymend/pymend.py"
-                ),
-                expected_stderr=re.compile(
-                    r"Usage: pymend \[OPTIONS\] SRC \.\.\..*"
-                    r"Error: Found unknown options in pyproject.toml: *",
-                    re.DOTALL,
-                ),
-                expected_returncode=2,
-            )
+        self.run_pymend_app_and_assert_is_expected(
+            cmd_args=(f"--config {pyproject_file} {self.CWD}/src/pymend/pymend.py"),
+            expected_stderr=re.compile(
+                r"Usage: pymend \[OPTIONS\] SRC \.\.\..*"
+                "Error: Found unknown options in pyproject.toml:"
+                r" invalid-option, other-invalid-option\.",
+                re.DOTALL,
+            ),
+            expected_returncode=2,
+        )
+
+    @pytest.mark.parametrize(
+        "option",
+        [
+            "diff",
+            "write",
+            "check-only",
+            "verbose",
+            "quiet",
+            "src",
+            "noforce-arg-types",
+            "unforce-arg-types",
+            "noforce-return-type",
+            "unforce-return-type",
+            "noforce-attribute-types",
+            "unforce-attribute-types",
+            "noforce-raises",
+            "force-raises-per-type",
+        ],
+    )
+    def test_cli_only_option_rejected_in_pyproject(
+        self, tmp_path: Path, option: str
+    ) -> None:
+        """Test that CLI-only options are not accepted in pyproject.toml."""
+        pyproject_file = tmp_path / "pyproject.toml"
+        pyproject_file.write_text(
+            textwrap.dedent(f"""\
+            [tool.pymend]
+            {option} = true
+        """)
+        )
+
+        self.run_pymend_app_and_assert_is_expected(
+            cmd_args=(f"--config {pyproject_file} {self.CWD}/src/pymend/pymend.py"),
+            expected_stderr=re.compile(
+                r"Usage: pymend \[OPTIONS\] SRC \.\.\..*"
+                r"Error: Found unknown option in pyproject.toml: *",
+                re.DOTALL,
+            ),
+            expected_returncode=2,
+        )
 
     def run_pymend_app_with_a_file_and_assert_is_expected(
         self,

--- a/tests/test_pymend/test_app.py
+++ b/tests/test_pymend/test_app.py
@@ -274,6 +274,78 @@ class TestApp:
             expected_returncode=1,
         )
 
+    def test_valid_pyproject_passes(self) -> None:
+        """Test that a valid option in pyproject succeeds."""
+        with tempfile.NamedTemporaryFile(mode="w", dir=self.CWD) as pyproject_file:
+            pyproject_file.write("[tool.pymend]\nforce-docstrings = false\n")
+            pyproject_file.flush()
+
+            self.run_pymend_app_and_assert_is_expected(
+                cmd_args=(
+                    f"--config {pyproject_file.name} {self.CWD}/src/pymend/pymend.py"
+                ),
+                expected_stderr=re.compile(
+                    "All done!",
+                    re.DOTALL,
+                ),
+            )
+
+    def test_invalid_value_type_pyproject_options_raises(self) -> None:
+        """Test that a valid option but with invalid type in pyproject fails."""
+        with tempfile.NamedTemporaryFile(mode="w", dir=self.CWD) as pyproject_file:
+            pyproject_file.write("[tool.pymend]\nforce-docstrings = '5'\n")
+            pyproject_file.flush()
+
+            self.run_pymend_app_and_assert_is_expected(
+                cmd_args=(
+                    f"--config {pyproject_file.name} {self.CWD}/src/pymend/pymend.py"
+                ),
+                expected_stderr=re.compile(
+                    r"Usage: pymend \[OPTIONS\] SRC \.\.\..*"
+                    r"Error: Invalid value for '--force-docstrings': '5'",
+                    re.DOTALL,
+                ),
+                expected_returncode=2,
+            )
+
+    def test_invalid_pyproject_option_raises(self) -> None:
+        """Test that a pyproject.toml file with an invalid option reports an error."""
+        with tempfile.NamedTemporaryFile(mode="w", dir=self.CWD) as pyproject_file:
+            pyproject_file.write("[tool.pymend]\ninvalid_option = '5'\n")
+            pyproject_file.flush()
+
+            self.run_pymend_app_and_assert_is_expected(
+                cmd_args=(
+                    f"--config {pyproject_file.name} {self.CWD}/src/pymend/pymend.py"
+                ),
+                expected_stderr=re.compile(
+                    r"Usage: pymend \[OPTIONS\] SRC \.\.\..*"
+                    r"Error: Found unknown option in pyproject.toml: *",
+                    re.DOTALL,
+                ),
+                expected_returncode=2,
+            )
+
+    def test_invalid_pyproject_options_raises(self) -> None:
+        """Test that a pyproject file with multiple invalid options raises an error."""
+        with tempfile.NamedTemporaryFile(mode="w", dir=self.CWD) as pyproject_file:
+            pyproject_file.write(
+                "[tool.pymend]\ninvalid-option = '5'\nother-invalid-option = true\n"
+            )
+            pyproject_file.flush()
+
+            self.run_pymend_app_and_assert_is_expected(
+                cmd_args=(
+                    f"--config {pyproject_file.name} {self.CWD}/src/pymend/pymend.py"
+                ),
+                expected_stderr=re.compile(
+                    r"Usage: pymend \[OPTIONS\] SRC \.\.\..*"
+                    r"Error: Found unknown options in pyproject.toml: *",
+                    re.DOTALL,
+                ),
+                expected_returncode=2,
+            )
+
     def run_pymend_app_with_a_file_and_assert_is_expected(
         self,
         file_contents: str,

--- a/tests/test_pymend/test_app.py
+++ b/tests/test_pymend/test_app.py
@@ -5,10 +5,10 @@ import re
 import subprocess
 import tempfile
 import textwrap
+from dataclasses import asdict
 from enum import Enum
 from pathlib import Path
 from re import Pattern
-from typing import Any
 
 import pytest
 
@@ -277,31 +277,49 @@ class TestApp:
         )
 
     def test_valid_pyproject_passes(self) -> None:
-        """Test that valid options in pyproject succeed."""
-        settings = pymend.pymend.FixerSettings()
-        options: list[tuple[str, Any]] = []
-        for name in dir(settings):
-            if name.startswith("_"):
-                # Ignore private attributes
-                continue
+        """Test that the valid options in pyproject succeed."""
+        options = [
+            ("force_docstrings", True),
+            ("force_params", True),
+            ("force_return", True),
+            ("force_raises", pymend.docstring_info.RaisesForceMode.PER_SITE),
+            ("force_methods", False),
+            ("force_attributes", False),
+            ("force_params_min_n_params", 0),
+            ("force_meta_min_func_length", 0),
+            ("ignore_privates", True),
+            ("ignore_unused_arguments", True),
+            ("ignored_decorators", ["overload"]),
+            ("ignored_functions", ["main"]),
+            ("ignored_classes", []),
+            ("force_defaults", True),
+            ("force_return_type", pymend.docstring_info.ForceOption.FORCE),
+            ("force_arg_types", pymend.docstring_info.ForceOption.FORCE),
+            ("force_attribute_types", pymend.docstring_info.ForceOption.FORCE),
+            ("force_summary_period", True),
+            ("force_summary_blank_line", True),
+            ("force_multiline_docs_end_with_blank", False),
+            ("indent", 4),
+            ("attribute_class_decorators", ["dataclass"]),
+            ("attribute_base_classes", ["BaseModel"]),
+            ("property_decorators", ["property"]),
+            ("additional_excluded_decorators", ["staticmethod", "classmethod"]),
+        ]
 
-            attr = getattr(settings, name)
-            if callable(attr):
-                # Skip methods
-                continue
-
-            # Convert all attributes to valid pyproject entries
-            if isinstance(attr, Enum):
-                attr = attr.value
-            if isinstance(attr, str):
-                attr = f'"{attr}"'
-            if isinstance(attr, bool):
-                attr = str(attr).lower()
-            options.append((name, attr))
+        settings_dict = asdict(pymend.pymend.FixerSettings())
+        assert len(options) == len(settings_dict)
+        for name, _ in options:
+            assert name in settings_dict
 
         with tempfile.NamedTemporaryFile(mode="w", dir=self.CWD) as pyproject_file:
             pyproject_file.write("[tool.pymend]\n")
             for name, value in options:
+                if isinstance(value, Enum):
+                    value = value.value  # noqa: PLW2901
+                if isinstance(value, str):
+                    value = f'"{value}"'  # noqa: PLW2901
+                if isinstance(value, bool):
+                    value = str(value).lower()  # noqa: PLW2901
                 pyproject_file.write(f"{name} = {value}\n")
             pyproject_file.flush()
 

--- a/tests/test_pymend/test_app.py
+++ b/tests/test_pymend/test_app.py
@@ -5,8 +5,10 @@ import re
 import subprocess
 import tempfile
 import textwrap
+from enum import Enum
 from pathlib import Path
 from re import Pattern
+from typing import Any
 
 import pytest
 
@@ -275,9 +277,32 @@ class TestApp:
         )
 
     def test_valid_pyproject_passes(self) -> None:
-        """Test that a valid option in pyproject succeeds."""
+        """Test that valid options in pyproject succeed."""
+        settings = pymend.pymend.FixerSettings()
+        options: list[tuple[str, Any]] = []
+        for name in dir(settings):
+            if name.startswith("_"):
+                # Ignore private attributes
+                continue
+
+            attr = getattr(settings, name)
+            if callable(attr):
+                # Skip methods
+                continue
+
+            # Convert all attributes to valid pyproject entries
+            if isinstance(attr, Enum):
+                attr = attr.value
+            if isinstance(attr, str):
+                attr = f'"{attr}"'
+            if isinstance(attr, bool):
+                attr = str(attr).lower()
+            options.append((name, attr))
+
         with tempfile.NamedTemporaryFile(mode="w", dir=self.CWD) as pyproject_file:
-            pyproject_file.write("[tool.pymend]\nforce-docstrings = false\n")
+            pyproject_file.write("[tool.pymend]\n")
+            for name, value in options:
+                pyproject_file.write(f"{name} = {value}\n")
             pyproject_file.flush()
 
             self.run_pymend_app_and_assert_is_expected(


### PR DESCRIPTION
Currently, you can just have any name in the `pyproject.toml`, and `PyMend` will not mind (actually there was one invalid option in the `PyMend` configuration as well, ironically :sweat_smile:). 

With this change, all of the options in `pyproject` are explicitly checked against the command-line options.

Closes #261 