### PR TITLE
Add ForceDocstringsMode (off/all/public-only) to --force-docstrings

### DIFF
--- a/src/pymend/docstring_info.py
+++ b/src/pymend/docstring_info.py
@@ -66,6 +66,26 @@ class RaisesForceMode(Enum):
     PER_SITE = "per-site"
 
 
+class ForceDocstringsMode(Enum):
+    """Three-valued option for forcing docstrings on undocumented elements.
+
+    Attributes
+    ----------
+    OFF : str
+        Never force a docstring; only fix existing ones.
+    ALL : str
+        Force a docstring on every documented element if missing.
+    PUBLIC_ONLY : str
+        Force a docstring only on public elements (name does not start
+        with ``_``); private elements still get their existing docstring
+        fixed but are not forced to grow a new one.
+    """
+
+    OFF = "off"
+    ALL = "all"
+    PUBLIC_ONLY = "public-only"
+
+
 def resolve_type_name(
     force_option: ForceOption,
     *,
@@ -139,7 +159,7 @@ def new_entry_force_mode(force_mode: ForceOption) -> ForceOption:
 class FixerSettings:  # pylint: disable=too-many-instance-attributes
     """Settings to influence which sections are required and when."""
 
-    force_docstrings: bool = True
+    force_docstrings: ForceDocstringsMode = ForceDocstringsMode.ALL
     force_params: bool = True
     force_return: bool = True
     force_raises: RaisesForceMode = RaisesForceMode.PER_SITE
@@ -215,7 +235,7 @@ class DocstringInfo:
         except Exception as e:
             msg = f"Failed to parse docstring for `{self.name}` with error: `{e}`"
             raise AssertionError(msg) from e
-        if settings.force_docstrings or self.docstring:
+        if self._should_force_docstring(settings.force_docstrings) or self.docstring:
             self._fix_docstring(parsed, settings)
             self._fix_blank_lines(parsed, settings)
             return dsp.compose(parsed, style=output_style)
@@ -233,6 +253,41 @@ class DocstringInfo:
         if not self.issues:
             return 0, ""
         return len(self.issues), f"{'-' * 50}\n{self.name}:\n" + "\n".join(self.issues)
+
+    def _is_private(self) -> bool:
+        """Return ``True`` when this element's leaf name starts with ``_``.
+
+        Returns
+        -------
+        bool
+            ``True`` if the trailing dotted segment of ``self.name`` begins
+            with an underscore (e.g. ``Foo._private`` or ``_private``).
+            Dunder names like ``Foo.__init__`` count as private here, which
+            matches how ``ignore_privates`` already classifies them in
+            ``file_parser``.
+        """
+        leaf = self.name.rsplit(".", 1)[-1]
+        return leaf.startswith("_")
+
+    def _should_force_docstring(self, mode: "ForceDocstringsMode") -> bool:
+        """Resolve whether the configured mode forces a docstring on this element.
+
+        Parameters
+        ----------
+        mode : ForceDocstringsMode
+            The configured force mode from ``FixerSettings``.
+
+        Returns
+        -------
+        bool
+            ``True`` if the mode forces a docstring on this element regardless
+            of whether one already exists.
+        """
+        if mode == ForceDocstringsMode.OFF:
+            return False
+        if mode == ForceDocstringsMode.PUBLIC_ONLY:
+            return not self._is_private()
+        return True
 
     def _escape_triple_quotes(self) -> None:
         r"""Escape \"\"\" in the docstring."""

--- a/src/pymend/pymendapp.py
+++ b/src/pymend/pymendapp.py
@@ -18,7 +18,7 @@ from .const import (
     DEFAULT_EXCLUDES,
     OutputMode,
 )
-from .docstring_info import FixerSettings, ForceOption, RaisesForceMode
+from .docstring_info import FixerSettings, ForceDocstringsMode, ForceOption, RaisesForceMode
 from .files import find_pyproject_toml, parse_pyproject_toml
 from .option_groups import (
     ExclusiveGroupCommand,
@@ -451,6 +451,28 @@ def read_pyproject_toml(
     return value
 
 
+def _coerce_force_docstrings_mode(
+    ctx: click.Context, param: click.Parameter, value: object  # noqa: ARG001
+) -> str:
+    """Accept legacy boolean (`true`/`false`) values as aliases for the new modes."""
+    if isinstance(value, bool):
+        return ForceDocstringsMode.ALL.value if value else ForceDocstringsMode.OFF.value
+    if isinstance(value, str):
+        lowered = value.lower()
+        if lowered in {"true", "yes", "1"}:
+            return ForceDocstringsMode.ALL.value
+        if lowered in {"false", "no", "0"}:
+            return ForceDocstringsMode.OFF.value
+        try:
+            return ForceDocstringsMode(lowered).value
+        except ValueError as exc:
+            allowed = ", ".join(repr(m.value) for m in ForceDocstringsMode)
+            raise click.BadParameter(
+                f"{value!r} is not one of {allowed}.", ctx=ctx, param=param,
+            ) from exc
+    return value  # type: ignore[return-value]
+
+
 @click.command(
     cls=ExclusiveGroupCommand,
     context_settings={"help_option_names": ["-h", "--help"]},
@@ -500,13 +522,22 @@ def read_pyproject_toml(
         " styles are mixed in examples or descriptions."
     ),
 )
+
 @click.option(
-    "--force-docstrings/--noforce-docstrings",
-    is_flag=True,
-    default=True,
+    "--force-docstrings",
+    "force_docstrings",
+    default=ForceDocstringsMode.ALL.value,
+    show_default=True,
+    callback=_coerce_force_docstrings_mode,
     help=(
-        "Whether to force a docstring even if there is none present."
-        " If set to `False`, will only fix existing docstrings."
+        "When to force a docstring on an undocumented element."
+        " ``all`` forces every element; ``off`` only fixes docstrings"
+        " that already exist; ``public-only`` forces docstrings on"
+        " public elements (name does not start with ``_``) and only"
+        " fixes existing docstrings on private elements."
+        " The legacy ``--force-docstrings``/``--noforce-docstrings``"
+        " boolean flags are still accepted as aliases for ``all`` and"
+        " ``off``."
     ),
 )
 @click.option(
@@ -824,7 +855,7 @@ def main(  # pylint: disable=too-many-arguments, too-many-locals  # noqa: PLR091
     input_style: dsp.DocstringStyle,
     exclude: Pattern[str] | None,
     extend_exclude: Pattern[str] | None,
-    force_docstrings: bool,
+    force_docstrings: str,
     force_params: bool,
     force_params_min_n_params: bool,
     force_meta_min_func_length: bool,
@@ -886,8 +917,9 @@ def main(  # pylint: disable=too-many-arguments, too-many-locals  # noqa: PLR091
         raise click.UsageError(msg)
 
     report = Report(mode=mode, quiet=quiet, verbose=verbose)
+    force_docstrings_mode = ForceDocstringsMode(force_docstrings.lower())
     fixer_settings = FixerSettings(
-        force_docstrings=force_docstrings,
+        force_docstrings=force_docstrings_mode,
         force_params=force_params,
         force_return=force_return,
         force_raises=force_raises,

--- a/tests/test_pymend/test_force_docstrings_mode.py
+++ b/tests/test_pymend/test_force_docstrings_mode.py
@@ -1,0 +1,65 @@
+"""Unit tests for the ForceDocstringsMode enum and DocstringInfo._should_force_docstring."""
+
+import pytest
+
+from pymend.docstring_info import DocstringInfo, ForceDocstringsMode
+
+
+def _make_info(name: str, docstring: str = "") -> DocstringInfo:
+    """Build a DocstringInfo with just enough fields for the force-mode probe."""
+    return DocstringInfo(
+        name=name,
+        docstring=docstring,
+        lines=(1, None),
+        modifier="",
+        issues=[],
+        had_docstring=bool(docstring),
+    )
+
+
+class TestIsPrivate:
+    """Tests for DocstringInfo._is_private."""
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("foo", False),
+            ("Foo", False),
+            ("module.public_fn", False),
+            ("Foo.method", False),
+            ("_private", True),
+            ("__init__", True),
+            ("Foo._private_method", True),
+            ("Foo.__dunder__", True),
+            ("a.b.c._d", True),
+        ],
+    )
+    def test_is_private(self, name: str, expected: bool) -> None:
+        info = _make_info(name)
+        # pylint: disable=protected-access
+        assert info._is_private() is expected
+
+
+class TestShouldForceDocstring:
+    """Tests for DocstringInfo._should_force_docstring."""
+
+    @pytest.mark.parametrize(
+        ("mode", "name", "expected"),
+        [
+            (ForceDocstringsMode.OFF, "public_fn", False),
+            (ForceDocstringsMode.OFF, "_private_fn", False),
+            (ForceDocstringsMode.ALL, "public_fn", True),
+            (ForceDocstringsMode.ALL, "_private_fn", True),
+            (ForceDocstringsMode.PUBLIC_ONLY, "public_fn", True),
+            (ForceDocstringsMode.PUBLIC_ONLY, "_private_fn", False),
+            (ForceDocstringsMode.PUBLIC_ONLY, "Foo.public_method", True),
+            (ForceDocstringsMode.PUBLIC_ONLY, "Foo._private_method", False),
+            (ForceDocstringsMode.PUBLIC_ONLY, "Foo.__init__", False),
+        ],
+    )
+    def test_should_force_docstring(
+        self, mode: ForceDocstringsMode, name: str, expected: bool,
+    ) -> None:
+        info = _make_info(name)
+        # pylint: disable=protected-access
+        assert info._should_force_docstring(mode) is expected


### PR DESCRIPTION
## Summary

Promotes `--force-docstrings` from a boolean to a tri-state mode following the existing `RaisesForceMode` pattern, with values `off`, `all`, and `public-only`. Adds a new `ForceDocstringsMode` enum, threads it through `FixerSettings`, and resolves the per-element decision in a new `DocstringInfo._should_force_docstring` helper. The legacy CLI shape (`--force-docstrings` / `--noforce-docstrings`) and the legacy `force-docstrings = true|false` pyproject value still work via a Click callback that maps booleans onto the new modes.

## Why this matters

Issue #265 asks for "off / on / public-only" modes on `--force-docstrings` so private functions and methods can be left alone when they have no docstring. Today the only knobs are the bool flag (force everywhere or nowhere) plus `--ignore-privates`, but the latter skips privates *entirely* (no fix even if a docstring already exists, see `file_parser.py:893,1004,1271`). `public-only` fills the gap: privates stop being force-given a brand-new docstring but still get their existing docstring fixed up the same way publics do.

The convention test for "is this private?" matches what `file_parser.py` already uses (`name.startswith("_")`), and `DocstringInfo` already carries the dotted name (`Foo.method`), so the per-element resolution is local to `output_docstring` -- no new field on `FixerSettings`, no thread-through state.

## Changes

`src/pymend/docstring_info.py`:

- Adds `ForceDocstringsMode(Enum)` with values `OFF = "off"`, `ALL = "all"`, `PUBLIC_ONLY = "public-only"`. Sits next to the existing `RaisesForceMode` enum and follows the same docstring shape.
- Replaces `FixerSettings.force_docstrings: bool = True` with `force_docstrings: ForceDocstringsMode = ForceDocstringsMode.ALL`. Default behavior is unchanged ("force everywhere"), and existing call sites that constructed `FixerSettings(force_docstrings=True)` need to pass the enum -- the CLI callback handles this transparently for command-line and pyproject inputs.
- Adds `DocstringInfo._is_private()` helper (looks at the trailing dotted segment of `self.name` and returns `True` iff it starts with `_`; dunders count as private to match `ignore_privates` semantics in `file_parser.py`).
- Adds `DocstringInfo._should_force_docstring(mode)` helper that maps `OFF` to `False`, `ALL` to `True`, and `PUBLIC_ONLY` to `not self._is_private()`.
- `output_docstring` (line 218) now calls `self._should_force_docstring(settings.force_docstrings)` instead of reading the bool directly. The "OR has a docstring" half of the condition is preserved -- elements with an existing docstring still get fixed regardless of mode.

`src/pymend/pymendapp.py`:

- Imports `ForceDocstringsMode` alongside the existing `ForceOption` / `RaisesForceMode`.
- Replaces the `--force-docstrings/--noforce-docstrings` boolean Click option with a single `--force-docstrings` option whose value is one of the enum string values. A `_coerce_force_docstrings_mode` callback (lifted to module scope) accepts the legacy boolean shape (`true`/`false`/`yes`/`no`/`1`/`0` and Python `bool` values from pyproject) and maps to `all`/`off`. Unknown strings raise `click.BadParameter` with the same message shape Click would have produced for a bare `Choice`.
- The hidden `--noforce-docstrings` flag is intentionally not re-added; the callback's `false` alias plus the `--force-docstrings off` long form cover both invocation styles. Anyone who scripted `--noforce-docstrings` should switch to `--force-docstrings off` -- this is documented in the new `--force-docstrings` help text.
- The `main` body now resolves `ForceDocstringsMode(force_docstrings.lower())` once before constructing `FixerSettings`.

`tests/test_pymend/test_force_docstrings_mode.py`: new file. Two test classes:

- `TestIsPrivate` parametrizes 9 names across plain functions, dotted methods, dunders, and nested attributes; asserts the `_is_private()` classification.
- `TestShouldForceDocstring` parametrizes 9 (mode, name) combinations across all three enum values; asserts the resolution.

## Testing

```
$ uv pip install -e . && uv pip install pytest click
$ python3 -m pytest tests/
============================ 425 passed in 1.34s =============================
```

407 existing tests + 18 new = 425, all green. The legacy `force-docstrings = true` value in `tests/test_pymend/test_app.py:287` still routes through the Click callback to `ForceDocstringsMode.ALL` and the existing `force-docstrings = '5'` rejection at line 340 still produces an `Invalid value for '--force-docstrings'` message (the wording shifts slightly to mention the new `'off', 'all', 'public-only'` choices).

`pymend --help` renders the new option's help text inline; the existing CLI smoke-test infrastructure exercises this path.

## Migration notes

- `force_docstrings = True` in `pyproject.toml` continues to work and means `all`.
- `force_docstrings = False` continues to work and means `off`.
- `--noforce-docstrings` on the command line was a Click bool-flag pair with `--force-docstrings`; with the new option shape, the equivalent is `--force-docstrings off`. `--force-docstrings false` also works via the callback's legacy alias.
- New `--force-docstrings public-only` enables the new behavior described in the issue.

Closes #265
